### PR TITLE
docs: add missing help text for tool publish options

### DIFF
--- a/src/crewai/cli/cli.py
+++ b/src/crewai/cli/cli.py
@@ -357,8 +357,8 @@ def tool_install(handle: str):
     default=False,
     help="Bypasses Git remote validations",
 )
-@click.option("--public", "is_public", flag_value=True, default=False)
-@click.option("--private", "is_public", flag_value=False)
+@click.option("--public", "is_public", flag_value=True, default=False, help="Publish tool as public")
+@click.option("--private", "is_public", flag_value=False, help="Publish tool as private")
 def tool_publish(is_public: bool, force: bool):
     tool_cmd = ToolCommand()
     tool_cmd.login()


### PR DESCRIPTION
- Add help text for --public option: "Publish tool as public"
- Add help text for --private option: "Publish tool as private"
- Improves CLI discoverability and user experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
